### PR TITLE
Add DrupalX Gov and Nonprofit recipes

### DIFF
--- a/recipes/drupalx-gov/content/node/contact.yml
+++ b/recipes/drupalx-gov/content/node/contact.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: b0503bab-23c6-43df-8d04-a724107498f5
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Contact Us'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /contact
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Get in touch with city officials and departments.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-gov/content/node/departments.yml
+++ b/recipes/drupalx-gov/content/node/departments.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: edcdceb2-cb7e-4b02-9bbf-1a8ce977bdd0
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Departments'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /departments
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Find information about each city department and the services they provide.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-gov/content/node/home.yml
+++ b/recipes/drupalx-gov/content/node/home.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d26cf12b-ab9e-4d69-b256-4a7f9021826b
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Home'
+  created:
+    - value: 1724541785
+  promote:
+    - value: true
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Welcome to the official government website. Find services and information for residents.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-gov/content/node/news.yml
+++ b/recipes/drupalx-gov/content/node/news.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: c52daa1d-dd49-48f8-8457-bab7757d9fed
+  bundle: article
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'City Council Approves Budget'
+  created:
+    - value: 1724541785
+  promote:
+    - value: true
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /news/city-council-approves-budget
+      langcode: en
+      pathauto: 1
+  body:
+    - value: |
+        <p>The city council has approved the annual budget for the upcoming fiscal year.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-gov/content/node/services.yml
+++ b/recipes/drupalx-gov/content/node/services.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 30f761f6-3942-4e69-9813-6d5152b371dc
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Services'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /services
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Access a variety of city services including permits, licenses, and community resources.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-gov/recipe.yml
+++ b/recipes/drupalx-gov/recipe.yml
@@ -1,0 +1,7 @@
+name: 'DrupalX Gov'
+description: 'Sample content for a typical government website.'
+type: 'Site'
+recipes:
+  - ../recipes/drupalx-core
+content:
+  import: '*'

--- a/recipes/drupalx-nonprofit/content/node/about.yml
+++ b/recipes/drupalx-nonprofit/content/node/about.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d3a0db05-d92a-421e-b15e-b99853f97a1f
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'About Us'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /about
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>We are committed to making a positive impact through our programs and initiatives.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-nonprofit/content/node/blog.yml
+++ b/recipes/drupalx-nonprofit/content/node/blog.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: df51de76-72a2-4642-a509-a63dad9189ed
+  bundle: article
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Impact Story'
+  created:
+    - value: 1724541785
+  promote:
+    - value: true
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /blog/impact-story
+      langcode: en
+      pathauto: 1
+  body:
+    - value: |
+        <p>Read how your support has transformed lives in our community.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-nonprofit/content/node/donate.yml
+++ b/recipes/drupalx-nonprofit/content/node/donate.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 917ad86a-a690-428e-9985-7040a9786787
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Donate'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /donate
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Your generous support helps us continue our mission.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-nonprofit/content/node/home.yml
+++ b/recipes/drupalx-nonprofit/content/node/home.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d85cb2cf-bd86-46f5-ac07-7cada6d965dc
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Home'
+  created:
+    - value: 1724541785
+  promote:
+    - value: true
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Welcome to our nonprofit organization. Learn about our mission and how you can help.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-nonprofit/content/node/programs.yml
+++ b/recipes/drupalx-nonprofit/content/node/programs.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 441fdf60-9dec-4345-88e1-c1c686aa6111
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Programs'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /programs
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Discover our various programs aimed at helping communities in need.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-nonprofit/recipe.yml
+++ b/recipes/drupalx-nonprofit/recipe.yml
@@ -1,0 +1,7 @@
+name: 'DrupalX Nonprofit'
+description: 'Sample content for a typical nonprofit website.'
+type: 'Site'
+recipes:
+  - ../recipes/drupalx-core
+content:
+  import: '*'

--- a/recipes/drupalx-university/content/node/about.yml
+++ b/recipes/drupalx-university/content/node/about.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d3758217-79a2-4ad1-80d7-e15f06ae8dea
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'About Us'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /about
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Founded over a century ago, our University is dedicated to academic excellence and student success.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-university/content/node/admissions.yml
+++ b/recipes/drupalx-university/content/node/admissions.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: a9876abf-0ab2-48ab-9161-709dc4e048ff
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Admissions'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /admissions
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Learn how to apply, explore financial aid options, and take the next step toward joining our community.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-university/content/node/contact.yml
+++ b/recipes/drupalx-university/content/node/contact.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 666f418c-64de-456b-968d-83db8b8c0553
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Contact Us'
+  created:
+    - value: 1724541785
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /contact
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Reach out to our admissions and support staff for more information about programs and campus visits.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-university/content/node/home.yml
+++ b/recipes/drupalx-university/content/node/home.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: a5e5dff3-aa0a-4c63-b4cf-7b3bcee49583
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'Home'
+  created:
+    - value: 1724541785
+  promote:
+    - value: true
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /
+      langcode: en
+      pathauto: 0
+  body:
+    - value: |
+        <p>Welcome to our University website. Explore our programs, research, and campus life.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-university/content/node/news.yml
+++ b/recipes/drupalx-university/content/node/news.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: e22b5204-e4c9-49f7-bda4-ec1ab4b1947a
+  bundle: article
+  default_langcode: en
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: 'University Welcomes New Students'
+  created:
+    - value: 1724541785
+  promote:
+    - value: true
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  path:
+    - alias: /news/university-welcomes-new-students
+      langcode: en
+      pathauto: 1
+  body:
+    - value: |
+        <p>Our university is excited to welcome a new class of students this fall semester.</p>
+      format: full_html
+      summary: ''

--- a/recipes/drupalx-university/recipe.yml
+++ b/recipes/drupalx-university/recipe.yml
@@ -1,0 +1,7 @@
+name: 'DrupalX University'
+description: 'Sample content for a typical university website.'
+type: 'Site'
+recipes:
+  - ../recipes/drupalx-core
+content:
+  import: '*'


### PR DESCRIPTION
## Summary
- add drupalx-gov recipe with demo content for government websites
- add drupalx-nonprofit recipe with demo content for nonprofit websites

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f78cc31288333a18ff1a45e9923b3